### PR TITLE
refactor(auth): Implementar LoginViewModel y AuthRepository

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/donacion_app/t2_apps/AuthRepository.kt
+++ b/app/src/main/java/com/donacion_app/t2_apps/AuthRepository.kt
@@ -1,0 +1,26 @@
+package com.donacion_app.t2_apps
+
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
+
+interface AuthRepository {
+    suspend fun login(email: String, password: String): Result<Boolean>
+    suspend fun sendRecoveryEmail(email: String): Result<Boolean>
+}
+
+class FirebaseAuthRepository : AuthRepository {
+    override suspend fun login(email: String, password: String): Result<Boolean> = try {
+        Firebase.auth.signInWithEmailAndPassword(email, password).await()
+        Result.success(true)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+    override suspend fun sendRecoveryEmail(email: String): Result<Boolean> = try {
+        Firebase.auth.sendPasswordResetEmail(email).await()
+        Result.success(true)
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/app/src/main/java/com/donacion_app/t2_apps/DishCard.kt
+++ b/app/src/main/java/com/donacion_app/t2_apps/DishCard.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 
-
 @Composable
 fun DishCard(
     dish: DishModel,

--- a/app/src/main/java/com/donacion_app/t2_apps/LoginScreen.kt
+++ b/app/src/main/java/com/donacion_app/t2_apps/LoginScreen.kt
@@ -1,6 +1,7 @@
 package com.donacion_app.t2_apps
 
 import android.widget.Toast
+import androidx.lifecycle.ViewModel
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -43,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
@@ -51,21 +53,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
 @Composable
-fun LoginScreen(rootNavController: NavHostController) {
+fun LoginScreen(rootNavController: NavHostController, viewModel: LoginViewModel = viewModel()) {
     val context = LocalContext.current
-    val email = remember { mutableStateOf("") }
-    val password = remember { mutableStateOf("") }
-    val recoveryEmail = remember { mutableStateOf("") }
-    val showDialog = remember { mutableStateOf(false) }
 
-    val scope = rememberCoroutineScope()
-    val isLoading = remember { mutableStateOf(false) }
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black.copy(alpha = 0.4f))
-    ) {
+    Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.4f))) {
         Image(
             painter = painterResource(id = R.drawable.fondo_restaurante), // Fondo de restaurante
             contentDescription = "Fondo",
@@ -104,8 +95,8 @@ fun LoginScreen(rootNavController: NavHostController) {
             Spacer(modifier = Modifier.height(24.dp))
 
             OutlinedTextField(
-                value = email.value,
-                onValueChange = { email.value = it },
+                value = viewModel.email,
+                onValueChange = { viewModel.email = it },
                 label = { Text("Correo electrónico") },
                 singleLine = true,
                 modifier = Modifier.fillMaxWidth(0.9f),
@@ -113,14 +104,14 @@ fun LoginScreen(rootNavController: NavHostController) {
                     unfocusedContainerColor = Color.White.copy(alpha = 0.9f),
                     focusedContainerColor = Color.White
                 ),
-                leadingIcon = { Icon(Icons.Default.Email, contentDescription = null) }
+                leadingIcon = { Icon(Icons.Default.Email, null) }
             )
 
             Spacer(modifier = Modifier.height(12.dp))
 
             OutlinedTextField(
-                value = password.value,
-                onValueChange = { password.value = it },
+                value = viewModel.password,
+                onValueChange = { viewModel.password = it },
                 label = { Text("Contraseña") },
                 singleLine = true,
                 visualTransformation = PasswordVisualTransformation(),
@@ -129,121 +120,76 @@ fun LoginScreen(rootNavController: NavHostController) {
                     unfocusedContainerColor = Color.White.copy(alpha = 0.9f),
                     focusedContainerColor = Color.White
                 ),
-                leadingIcon = { Icon(Icons.Default.Lock, contentDescription = null) }
+                leadingIcon = { Icon(Icons.Default.Lock, null) }
             )
 
             Spacer(modifier = Modifier.height(20.dp))
 
             Button(
                 onClick = {
-                    scope.launch {
-                        isLoading.value = true
-                        val result = loginUser(email.value, password.value)
-                        isLoading.value = false
-                        if (result) {
+                    viewModel.login(
+                        onSuccess = {
                             rootNavController.navigate("main") {
                                 popUpTo("login") { inclusive = true }
                             }
-                        } else {
-                            Toast.makeText(context, "Error de login", Toast.LENGTH_SHORT).show()
+                        },
+                        onFailure = {
+                            Toast.makeText(context, it, Toast.LENGTH_SHORT).show()
                         }
-                    }
+                    )
                 },
-                modifier = Modifier
-                    .fillMaxWidth(0.9f)
-                    .height(50.dp),
+                modifier = Modifier.fillMaxWidth(0.9f).height(50.dp),
                 colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4CAF50))
             ) {
                 Text("Iniciar Sesión", color = Color.White)
             }
 
-            if (isLoading.value) {
-                Spacer(modifier = Modifier.height(12.dp))
-                CircularProgressIndicator()
-            }
-
+            if (viewModel.isLoading) CircularProgressIndicator()
             Spacer(modifier = Modifier.height(12.dp))
 
             Button(
-                onClick = { showDialog.value = true },
-                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF6A1B9A)),
-                modifier = Modifier
-                    .fillMaxWidth(0.9f)
-                    .height(50.dp)
+                onClick = { viewModel.showDialog = true },
+                modifier = Modifier.fillMaxWidth(0.9f).height(50.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF6A1B9A))
             ) {
                 Text("Olvidé mi contraseña", color = Color.White)
-                Spacer(modifier = Modifier.width(8.dp))
-                Icon(Icons.Default.Email, contentDescription = null, tint = Color.White)
             }
 
-            Spacer(modifier = Modifier.height(20.dp))
-
-            TextButton(onClick = {
-                rootNavController.navigate("register")
-            }) {
+            TextButton(onClick = { rootNavController.navigate("register") }) {
                 Text("¿No tienes cuenta? Regístrate aquí", color = Color.White)
             }
         }
     }
 
-    // Diálogo de recuperación de contraseña
-    if (showDialog.value) {
+    if (viewModel.showDialog) {
         AlertDialog(
-            onDismissRequest = {
-                showDialog.value = false
-                recoveryEmail.value = ""
-            },
+            onDismissRequest = { viewModel.showDialog = false },
             title = { Text("Recuperar contraseña") },
             text = {
-                Column {
-                    Text("Ingresa tu correo registrado")
-                    Spacer(Modifier.height(8.dp))
-                    OutlinedTextField(
-                        value = recoveryEmail.value,
-                        onValueChange = { recoveryEmail.value = it },
-                        label = { Text("Correo electrónico") },
-                        singleLine = true
-                    )
-                }
+                OutlinedTextField(
+                    value = viewModel.recoveryEmail,
+                    onValueChange = { viewModel.recoveryEmail = it },
+                    label = { Text("Correo electrónico") }
+                )
             },
             confirmButton = {
                 TextButton(onClick = {
-                    if (recoveryEmail.value.isNotBlank()) {
-                        FirebaseAuth.getInstance().sendPasswordResetEmail(recoveryEmail.value)
-                            .addOnSuccessListener {
-                                Toast.makeText(context, "Correo de recuperación enviado", Toast.LENGTH_LONG).show()
-                                recoveryEmail.value = ""
-                                showDialog.value = false
-                            }
-                            .addOnFailureListener {
-                                Toast.makeText(context, "Error: ${it.message}", Toast.LENGTH_LONG).show()
-                            }
-                    } else {
-                        Toast.makeText(context, "Correo requerido", Toast.LENGTH_SHORT).show()
-                    }
-                }) {
-                    Text("Enviar")
-                }
+                    viewModel.sendRecoveryEmail(
+                        onSuccess = {
+                            Toast.makeText(context, "Correo enviado", Toast.LENGTH_LONG).show()
+                            viewModel.showDialog = false
+                        },
+                        onFailure = {
+                            Toast.makeText(context, it, Toast.LENGTH_LONG).show()
+                        }
+                    )
+                }) { Text("Enviar") }
             },
             dismissButton = {
-                TextButton(onClick = {
-                    showDialog.value = false
-                    recoveryEmail.value = ""
-                }) {
+                TextButton(onClick = { viewModel.showDialog = false }) {
                     Text("Cancelar")
                 }
             }
         )
-    }
-}
-
-// Función de login usando Firebase Auth
-suspend fun loginUser(email: String, password: String): Boolean {
-    return try {
-        Firebase.auth.signInWithEmailAndPassword(email, password).await()
-        true
-    } catch (e: Exception) {
-        e.printStackTrace()
-        false
     }
 }

--- a/app/src/main/java/com/donacion_app/t2_apps/LoginViewModel.kt
+++ b/app/src/main/java/com/donacion_app/t2_apps/LoginViewModel.kt
@@ -1,0 +1,39 @@
+package com.donacion_app.t2_apps
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+
+class LoginViewModel(private val authRepository: AuthRepository = FirebaseAuthRepository()) : ViewModel() {
+
+    var email by mutableStateOf("")
+    var password by mutableStateOf("")
+    var recoveryEmail by mutableStateOf("")
+    var isLoading by mutableStateOf(false)
+    var showDialog by mutableStateOf(false)
+
+    fun login(onSuccess: () -> Unit, onFailure: (String) -> Unit) {
+        viewModelScope.launch {
+            isLoading = true
+            val result = authRepository.login(email, password)
+            isLoading = false
+            result.fold(
+                onSuccess = { onSuccess() },
+                onFailure = { onFailure(it.message ?: "Error desconocido") }
+            )
+        }
+    }
+
+    fun sendRecoveryEmail(onSuccess: () -> Unit, onFailure: (String) -> Unit) {
+        viewModelScope.launch {
+            val result = authRepository.sendRecoveryEmail(recoveryEmail)
+            result.fold(
+                onSuccess = { onSuccess() },
+                onFailure = { onFailure(it.message ?: "Error al enviar correo") }
+            )
+        }
+    }
+}


### PR DESCRIPTION
Se refactorizó la pantalla de Login (LoginScreen) para desacoplar la lógica de presentación de la lógica de negocio y acceso a datos.

Cambios realizados:
- Se creó la clase AuthRepository para centralizar las operaciones de autenticación (login, registro, recuperación de contraseña) con Firebase Authentication.
- Se creó LoginViewModel para manejar el estado de la UI de LoginScreen y las interacciones con AuthRepository.
- LoginScreen ahora consume los estados y acciones del LoginViewModel, lo que la hace más "tonta" y más fácil de mantener.
- Se eliminó la lógica directa de Firebase Auth de LoginScreen.